### PR TITLE
ath79: Forward port support for CR3000 based on ar71xx

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -28,6 +28,13 @@ case "$board" in
 	ucidef_set_led_switch "lan1" "LAN1" "netgear:green:lan1" "switch0" "0x02" "0x0f"
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
+"pcs,cr3000")
+	ucidef_set_led_netdev "wan" "WAN" "pcs:blue:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "pcs:blue:lan1" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "LAN2" "pcs:blue:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "pcs:blue:lan3" "switch0" "0x10"
+	ucidef_set_led_switch "lan4" "LAN4" "pcs:blue:lan4" "switch0" "0x02"
+	;;
 "tplink,re450-v2")
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -42,6 +42,12 @@ ath79_setup_interfaces()
 		"0@eth1" "1:lan" "2:lan" "3:lan:3" "4:lan:4"
 		;;
 
+	"pcs,cr3000")
+		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+		;;
+
 	"tplink,tl-archer-c7-v2")
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"

--- a/target/linux/ath79/base-files/lib/preinit/03_swap_iface_names_ath79
+++ b/target/linux/ath79/base-files/lib/preinit/03_swap_iface_names_ath79
@@ -1,0 +1,14 @@
+
+preinit_swap_ethernet_names() {
+	. /lib/functions.sh
+
+	case $(board_name) in
+	pcs,cr3000)
+		ip link set eth0 name eth999
+		ip link set eth1 name eth0
+		ip link set eth999 name eth1
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_swap_ethernet_names

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	model = "PowerCloud Systems CR3000";
+	compatible = "pcs,cr3000", "qca,ar9344";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &status;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-names = "default";
+                pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status: power {
+			label = "pcs:amber:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "pcs:blue:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan {
+			label = "pcs:blue:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1 {
+			label = "pcs:blue:lan1";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2 {
+			label = "pcs:blue:lan2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan3 {
+			label = "pcs:blue:lan3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan4 {
+			label = "pcs:blue:lan4";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x07a0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&art 0x0>;
+
+};
+
+&eth1 {
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -66,6 +66,15 @@ define Device/openmesh_om5p-ac-v2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
 
+define Device/pcs_cr3000
+  ATH_SOC := ar9341
+  DEVICE_TITLE := PowerCloud Systems CR3000
+  IMAGE_SIZE := 7808k
+  IMAGES := sysupgrade.bin
+  SUPPORTED_DEVICES += cr3000
+endef
+TARGET_DEVICES += pcs_cr3000
+
 define Device/netgear_wndr3800
   ATH_SOC := ar7161
   DEVICE_TITLE := NETGEAR WNDR3800


### PR DESCRIPTION
@981213 Hi - sending the PR to you because this board depends on the changes in your PR for splitting up ag71xx driver; if don't want to add to your PR, I can submit to openwrt once your PR is accepted.

The PowerCloud Systems CR3000 was a cloud-managed CPE for
a now defunct NaaS offering.  It was previously supported
under the ar71xx branch and this forward ports that support
with some notable differences:

1) Since reverting to stock firmware is now irrelevant there is
is only a single openwrt image generated which uses the entire
flash rather than preserving PowerCloud-specific partitions
that are unneeded to openwrt -- those partitions will be erased
and used by the openwrt image.

2) Rather than use a non-standard probe order for the ethernet
devices, this image uses a set of 'ip link set ethX name ethY'
commands very early in preinit (before the network is used at all),
in order to have the the switch and Wan use the same ethernet names
as in previous images.

3) /etc/config/wireless will need to be regenerated as the path
to the wireless device has changed due to differences in ath79
DT for ar93x compared to ar71xx images.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>
